### PR TITLE
Check the VMware version later

### DIFF
--- a/vmwh.c
+++ b/vmwh.c
@@ -34,7 +34,6 @@ main(int argc, char *argv[])
 	int ch;
 
 	x11_verify_xclip_presence();
-	vmware_check_version();
 
 	while ((ch = getopt(argc, argv, "dm")) != -1)
 		switch (ch) {
@@ -49,6 +48,8 @@ main(int argc, char *argv[])
 		}
 	argc -= optind;
 	argv += optind;
+
+	vmware_check_version();
 
 	vmware_get_mouse_position();
 


### PR DESCRIPTION
This allows the version information to be printed if the `-d` flag is set.

Otherwise `debug` will always be `0` and the debugging info won't get printed in
`vmware_check_version`.