### PR TITLE
Remove dependency on bsd make extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: $(PROG)
 $(PROG): $(OBJS)
 	$(CC) $(OBJS) $(LDPATH) $(LIBS) -o $@
 
-$(OBJS): *.o: *.c
+.c.o:
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 install: all


### PR DESCRIPTION
This change enables building with either BSD or GNU make.