### PR TITLE
Include stdint.h

### DIFF
--- a/vmware.c
+++ b/vmware.c
@@ -16,6 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/vmwh.c
+++ b/vmwh.c
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <err.h>


### PR DESCRIPTION
Fixes compilation errors on linux due to missing int16_t declarations.